### PR TITLE
Relax requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,8 @@ setup(
     },
     zip_safe=False,
     install_requires=[
-        "certifi==2018.1.18",
-        "chardet==3.0.4",
-        "idna==2.6",
-        "Jinja2==2.10",
-        "MarkupSafe==1.0",
-        "requests==2.18.4",
-        "urllib3==1.22",
-        "xmltodict==0.11.0",
+        "Jinja2>=2.10",
+        "requests>=2.18.4",
+        "xmltodict>=0.11.0",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
     name='service_person_stamdata_udvidet',
     version='0.1.0',
     description='',
-    author='Steffen Park',
-    author_email='steffen@magenta.dk',
+    author='Magenta ApS',
+    author_email='info@magenta.dk',
     license="MPL 2.0",
     packages=find_packages(),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages
 
 setup(
     name='service_person_stamdata_udvidet',
-    version='0.1.0',
+    version='0.1.1',
     description='',
     author='Magenta ApS',
     author_email='info@magenta.dk',


### PR DESCRIPTION
Hardcoding `certifify` can cause issues with installing newer versions of `requests` in users of this library. For more info, see the individual commits.