### PR TITLE
fix deprecation warning

### DIFF
--- a/service_person_stamdata_udvidet/udvidet_person_stam_data_lokal.py
+++ b/service_person_stamdata_udvidet/udvidet_person_stam_data_lokal.py
@@ -26,7 +26,7 @@ test_service_url = (
 
 
 def get_citizen(service_uuids, certificate, cprnr, production=True):
-    """
+    r"""
     The function returnes a citizen dict from the
     'SF1520 - Udvidet person stamdata (lokal)' service.
     It serves as a facade to simplify input validation, and interaction


### PR DESCRIPTION
```
=============================== warnings summary ===============================
../../usr/local/lib/python3.7/site-packages/service_person_stamdata_udvidet/udvidet_person_stam_data_lokal.py:65
  /usr/local/lib/python3.7/site-packages/service_person_stamdata_udvidet/udvidet_person_stam_data_lokal.py:65: DeprecationWarning: invalid escape sequence \d
```
https://www.python.org/dev/peps/pep-0257/#id15
> Use r"""raw triple double quotes""" if you use any backslashes in your docstrings.